### PR TITLE
make shadertoys copypasta as long as uniforms are setup in settings for each, switched to webgl2/300es 

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "prettier": "^2.3.0",
     "ts-jest": "^27.0.2",
     "typescript": "^4.3.2"
+  },
+  "dependencies": {
+    "@types/ws": "8.5.4"
   }
 }

--- a/src/GlueProgram.ts
+++ b/src/GlueProgram.ts
@@ -122,7 +122,7 @@ export class GlueProgram {
     gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, rectangleBuffer, gl.STATIC_DRAW);
 
-    const positionLocation = gl.getAttribLocation(this._program, 'position');
+    const positionLocation = gl.getAttribLocation(this._program, 'pos');
     gl.enableVertexAttribArray(positionLocation);
     gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
   }

--- a/src/GlueShaderSources.ts
+++ b/src/GlueShaderSources.ts
@@ -37,14 +37,25 @@ export enum GlueBlendMode {
   DARKER_COLOR,
 }
 
-export const defaultFragmentShader = `void main() {
-  vec2 p = gl_FragCoord.xy / iResolution;
-  gl_FragColor = texture2D(iTexture, p);
-}`;
-
-export const defaultVertexShader = `void main() {
-  gl_Position = vec4(position, 1.0);
-}`;
+// export const defaultFragmentShader = `void main() {
+//   vec2 p = gl_FragCoord.xy / iResolution;
+//   gl_FragColor = texture2D(iTexture, p);
+// }`;
+// vsSourceD = "layout(location = 0) in vec2 pos; void main() { gl_Position = vec4(pos.xy,0.0,1.0); }";
+//         fsSourceD = "uniform vec4 v; uniform sampler2D t; out vec4 outColor; void main() { vec2 uv = gl_FragCoord.xy / v.zw; outColor = texture(t, vec2(uv.x,1.0-uv.y)); }";
+export const defaultFragmentShader = `
+void mainImage( out vec4 fragColor, in vec2 fragCoord ){
+//  fragColor = vec4(0.0,0.0,1.0,1.0);
+  vec2 uv = fragCoord.xy / iResolution;
+  fragColor = texture(iTexture, uv);
+}
+`
+export const defaultVertexShader = `
+  void main() { gl_Position = vec4(pos.xy,0.0,1.0); }
+`
+// export const defaultVertexShader = `void main() {
+//   gl_Position = vec4(position, 1.0);
+// }`;
 
 // Source: https://github.com/jamieowen/glsl-blend
 

--- a/src/GlueUtils.ts
+++ b/src/GlueUtils.ts
@@ -12,7 +12,7 @@ export function glueIsWebGLAvailable(): boolean {
     const canvas = document.createElement('canvas');
     return !!(
       window.WebGLRenderingContext &&
-      (canvas.getContext('webgl') || canvas.getContext('experimental-webgl'))
+      (canvas.getContext('webgl2') || canvas.getContext('experimental-webgl2'))
     );
   } catch (e) {
     return false;
@@ -35,9 +35,16 @@ export function glueGetWebGLContext(
     };
   }
 
+   var opts = { alpha: false, 
+                 depth: false, 
+                 stencil: false, 
+                 premultipliedAlpha: false, 
+                 antialias: false, 
+                 preserveDrawingBuffer: true, 
+                 powerPreference: "high-performance" }; // "low_power", "high_performance", "default"
   const context =
-    canvas.getContext('webgl', options) ||
-    canvas.getContext('experimental-webgl', options);
+    canvas.getContext('webgl2', opts) ||
+    canvas.getContext('experimental-webgl2', opts);
 
   if (!context) {
     throw new Error('WebGL is not available.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,6 +835,13 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/ws@8.5.4":
+  version "8.5.4"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.4.tgz#bb10e36116d6e570dd943735f86c933c1587b8a5"
+  integrity sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"


### PR DESCRIPTION
While this isn't the exact goal... and i wouldn't approve any part of this because its not really shiny/doc'd/commented but for anyone curious, this change to the shader header prefixes makes it so you can pretty much take any shadertoy that is NOT multi-pass/multi fbo, and run with it in `fxGlue`. pretty much as long as you can have the missing uniforms (itime,idate,imouse) edited out, or added as settings/uniforms in studio, it implements the same signatures and uses same version as shadertoy

I am not really trying to get this upstream exactly... 

honestly im using this PR to try and ping @mat-sz and for my fork to maybe get some visibility to anyone who looks this way...

@mat-sz you've made an awesome base/starter for a multi-layered motion/generated graphic editor in instaglitch...  i've posted some clips on twitter of what i've been doing with your awesome instaglitch, fxGlue, studio... wanted to comment/shoot shit/collab maybe? use them duckets and hit mine up.